### PR TITLE
Fix Paper Cuts For Running Node

### DIFF
--- a/integrations/node/Dockerfile
+++ b/integrations/node/Dockerfile
@@ -1,7 +1,14 @@
 FROM node:lts-alpine
 
+RUN apk add --no-cache python g++ make
+
 COPY package.json .
 COPY yarn.lock .
+
+RUN apk --no-cache --virtual build-dependencies add \
+	python \
+        make \
+        g++
 
 RUN yarn install
 

--- a/integrations/node/README.md
+++ b/integrations/node/README.md
@@ -28,7 +28,7 @@ Your config should look like this:
   "pools": {
     "0": 1,
     "2": 10,
-    ....
+    // add further pool ids here
   }
 }
 ```

--- a/integrations/node/src/index.ts
+++ b/integrations/node/src/index.ts
@@ -1,4 +1,4 @@
-require("dotenv").config();
+require("dotenv").config({silent: true});
 import KYVE from "@kyve/core";
 import Contract from "@kyve/contract-lib";
 import Arweave from "arweave";


### PR DESCRIPTION
This PR suggests some minor fixes relating to the instructions in https://github.com/KYVENetwork/kyve/tree/master/integrations/node#readme.

Specifically I encountered these paper cuts:

- `yarn node:build` failed probably due to running things on Apple M1 silicon. This seems to be the issue: https://githubmemory.com/repo/docker/getting-started/issues/124; fix in `Dockerfile`
- `yarn node:run` failed due to this issue: https://github.com/motdotla/dotenv/issues/135#issuecomment-212433865; fix in `src/index.ts`

I'm not 100% sure whether these changes would have side effects on other machines, perhaps you could verify?