### PR TITLE
refactor: avoid calling `loadContract` when not necessary

### DIFF
--- a/common/query/src/smartweave.ts
+++ b/common/query/src/smartweave.ts
@@ -41,8 +41,10 @@ export const readContract = async (
     ).value
   );
 
-  const data: { state: object } = JSON.parse(await getData(transaction.id));
+  const data: { state: object; validity: { [txID: string]: boolean } } =
+    JSON.parse(await getData(transaction.id));
   let state = data.state;
+  let validity = data.validity;
 
   // find txs which have not been added to state
 
@@ -61,11 +63,8 @@ export const readContract = async (
     ])
     .findAll()) as GQLEdgeTransactionInterface[];
 
-  const validity: Record<string, boolean> = {};
-
   if (missingTXs.length == 0) {
     // return immediately to avoid call to loadContract function (which is slooooow)
-    // note: not sure what to do with validity?
     return returnValidity ? { state, validity } : state;
   }
 

--- a/common/query/src/smartweave.ts
+++ b/common/query/src/smartweave.ts
@@ -61,6 +61,14 @@ export const readContract = async (
     ])
     .findAll()) as GQLEdgeTransactionInterface[];
 
+  const validity: Record<string, boolean> = {};
+
+  if (missingTXs.length == 0) {
+    // return immediately to avoid call to loadContract function (which is slooooow)
+    // note: not sure what to do with validity?
+    return returnValidity ? { state, validity } : state;
+  }
+
   // from https://github.com/ArweaveTeam/SmartWeave/blob/master/src/contract-read.ts#L56
   // TODO: FIX ONCE https://github.com/ArweaveTeam/SmartWeave/pull/82 is merged
 
@@ -68,8 +76,6 @@ export const readContract = async (
 
   const contractInfo = await loadContract(arweave, contractID);
   const { handler, swGlobal } = contractInfo;
-
-  const validity: Record<string, boolean> = {};
 
   for (const txInfo of missingTXs) {
     const tags = formatTags(txInfo.node.tags);


### PR DESCRIPTION
Avoid calling to "loadContract" and replaying the "rest" of the state, if state in cache is up-to-date